### PR TITLE
add timeout for compiling of cpu evaluator

### DIFF
--- a/platforms/c-mcpu/evaluator/eval_agent/eval_agent.py
+++ b/platforms/c-mcpu/evaluator/eval_agent/eval_agent.py
@@ -204,8 +204,8 @@ return 0;
 def build_source_file():
     try:
         if platform.system() == 'Linux':
-            cmd = ['g++', 'main.cpp', '-omain', '-std=c++11', '-lpthread', '-O3', '-march=native']
-            output = subprocess.check_output(cmd)
+            cmd = ['timeout', '120s', 'g++', 'main.cpp', '-omain', '-std=c++11', '-lpthread', '-O3', '-march=native']
+            output = subprocess.check_output(cmd, timeout=120)
         else:
             pass
     except CalledProcessError as e:


### PR DESCRIPTION
Some long kernel functions may need much time to compile, add  2 minutes timeout for the compiling phase.