### PR TITLE
[SYCL] Use of Unified Shared Memory

### DIFF
--- a/backends/c-sycl_intel/config.py
+++ b/backends/c-sycl_intel/config.py
@@ -10,15 +10,10 @@ def get_execution_parallism():
 def do_native_translation_v2(codeset, **kwargs):
   kernel_name, in_args, out_args, body = codeset
 
-  if backend == 'c-sycl_intel':  # Issue: Data over SYCL Buffer & Accessor is very slow on Intel CPU
-    expand_ins = [f'const auto* {x[1]} = ({x[0]}* __restrict)__args[{i}];' for i, x in enumerate(in_args)]
-    expand_outs = [f'auto* {x[1]} = ({x[0]}* __restrict)__args[{i + len(in_args)}];' for i, x in enumerate(out_args)]
-    expand_args = ' '.join(expand_ins + expand_outs)
-    expand_accs = expand_ptrs = ''
-  else:                          # Using standard SYCL Buffer & Accessor
-    expand_args = '\n  '.join([f'auto &__args_{i} = *((cl::sycl::buffer<{x[0]}>*)__args[{i}]);' for i, x in enumerate(in_args + out_args)])
-    expand_accs = '\n    '.join([f'auto __accs_{i} = __args_{i}.get_access<cl::sycl::access::mode::{"read" if i < len(in_args) else "discard_write"}>(cgh);' for i, x in enumerate(in_args + out_args)]) + '\n'
-    expand_ptrs = '\n      '.join([f'{x[0]}* {x[1]} = ({x[0]}*)__accs_{i}.get_pointer();' for i, x in enumerate(in_args + out_args)]) + '\n'
+  expand_ins = [f'const auto* {x[1]} = ({x[0]}* __restrict)__args[{i}];' for i, x in enumerate(in_args)]
+  expand_outs = [f'auto* {x[1]} = ({x[0]}* __restrict)__args[{i + len(in_args)}];' for i, x in enumerate(out_args)]
+  expand_args = ' '.join(expand_ins + expand_outs)
+  expand_accs = expand_ptrs = ''
 
   def get_extent(key, defval=1):
     str_pat = f'// [thread_extent] {key} = '

--- a/backends/c-sycl_intel/include/backend.hpp
+++ b/backends/c-sycl_intel/include/backend.hpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //; eval_flags(c-sycl_intel): [dpcpp] -ldl -lpthread
-//; eval_flags(c-sycl_cuda): [/usr/local/dpcpp-cuda/bin/clang++] -O3 -ldl -I/usr/local/dpcpp-cuda/include/sycl -L/usr/local/dpcpp-cuda/lib -lsycl -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice -fsycl-unnamed-lambda -lpthread
+//; eval_flags(c-sycl_cuda): [/usr/local/dpcpp-cuda/bin/clang++] -O3 -ldl -I/usr/local/dpcpp-cuda/include/sycl -L/usr/local/dpcpp-cuda/lib -lsycl -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice -fsycl-unnamed-lambda -lpthread -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75
 
 #include <CL/sycl.hpp>
 #include <dlfcn.h>
@@ -57,7 +57,7 @@ namespace ab {
     if (__BACKEND__ == "c-sycl_intel")
       ab_utils::Process({"dpcpp", path, "-std=c++17", "-lpthread", "-fPIC", "-shared", "-Wno-pass-failed", "-O3", "-ffast-math", "-march=skylake-avx512", "-o", path + ".out"}, 10);
     else
-      ab_utils::Process({"/usr/local/dpcpp-cuda/bin/clang++", path, "-std=c++17", "-ldl", "-fPIC", "-shared", "-O2", "-I/usr/local/dpcpp-cuda/include/sycl", "-L/usr/local/dpcpp-cuda/lib", "-lsycl", "-fsycl", "-fsycl-targets=nvptx64-nvidia-cuda-sycldevice", "-fsycl-unnamed-lambda", "-Wno-unknown-cuda-version", "-o", path + ".out"}, 20);
+      ab_utils::Process({"/usr/local/dpcpp-cuda/bin/clang++", path, "-std=c++17", "-ldl", "-fPIC", "-shared", "-O2", "-I/usr/local/dpcpp-cuda/include/sycl", "-L/usr/local/dpcpp-cuda/lib", "-lsycl", "-fsycl", "-fsycl-targets=nvptx64-nvidia-cuda-sycldevice", "-fsycl-unnamed-lambda", "-Wno-unknown-cuda-version", "-Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75", "-o", path + ".out"}, 20);
 
     path = (path[0] == '/' ? path : "./" + path) + ".out";
     void* hmod = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);

--- a/backends/c-sycl_intel/include/backend.hpp
+++ b/backends/c-sycl_intel/include/backend.hpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //; eval_flags(c-sycl_intel): [dpcpp] -ldl -lpthread
-//; eval_flags(c-sycl_cuda): [/usr/local/dpcpp-cuda/bin/clang++] -O3 -ldl -I/usr/local/dpcpp-cuda/include/sycl -L/usr/local/dpcpp-cuda/lib -lsycl -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice -fsycl-unnamed-lambda -lpthread -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75
+//; eval_flags(c-sycl_cuda): [/usr/local/dpcpp-cuda/bin/clang++] -ldl -I/usr/local/dpcpp-cuda/include/sycl -L/usr/local/dpcpp-cuda/lib -lsycl -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice -fsycl-unnamed-lambda -lpthread
 
 #include <CL/sycl.hpp>
 #include <dlfcn.h>

--- a/backends/c-sycl_intel/include/backend.hpp
+++ b/backends/c-sycl_intel/include/backend.hpp
@@ -78,14 +78,14 @@ namespace ab {
     if (__BACKEND__ == "c-sycl_intel")
       ab_utils::Process({"dpcpp", path, "-std=c++17", "-lpthread", "-fPIC", "-shared", "-Wno-pass-failed", "-O3", "-ffast-math", "-march=skylake-avx512", "-o", path + ".out"}, 10);
     else {
-    std::string gpu_arch = "50"; // Corresponds to the back-end default.
+      std::string gpu_arch = "50"; // Corresponds to the back-end default.
 #ifdef SYCL_CUDA
-    int major, minor;
-    CHECK_OK(0 == cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, 0));
-    CHECK_OK(0 == cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, 0));
-    gpu_arch = std::to_string(major * 10 + minor);
+      int major, minor;
+      CHECK_OK(0 == cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, 0));
+      CHECK_OK(0 == cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, 0));
+      gpu_arch = std::to_string(major * 10 + minor);
 #endif
-      ab_utils::Process({"/usr/local/dpcpp-cuda/bin/clang++", path, "-std=c++17", "-ldl", "-fPIC", "-shared", "-O2", "-I/usr/local/dpcpp-cuda/include/sycl", "-L/usr/local/dpcpp-cuda/lib", "-lsycl", "-fsycl", "-fsycl-targets=nvptx64-nvidia-cuda-sycldevice", "-fsycl-unnamed-lambda", "-Wno-unknown-cuda-version", "-Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_" + gpu_arch, "-o", path + ".out"}, 20);  
+      ab_utils::Process({"/usr/local/dpcpp-cuda/bin/clang++", path, "-std=c++17", "-ldl", "-fPIC", "-shared", "-O2", "-I/usr/local/dpcpp-cuda/include/sycl", "-L/usr/local/dpcpp-cuda/lib", "-lsycl", "-fsycl", "-fsycl-targets=nvptx64-nvidia-cuda-sycldevice", "-fsycl-unnamed-lambda", "-Wno-unknown-cuda-version", "-Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_" + gpu_arch, "-o", path + ".out"}, 20);
     }
     path = (path[0] == '/' ? path : "./" + path) + ".out";
     void* hmod = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
@@ -116,7 +116,6 @@ namespace ab {
     ab::synchronize(stream);
     _sycl_queue.memcpy(hptr, dptr, byteSize);
     return;
-    
   }
 
   void* recordTime(void *stream) {

--- a/backends/c-sycl_intel/include/backend.hpp
+++ b/backends/c-sycl_intel/include/backend.hpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //; eval_flags(c-sycl_intel): [dpcpp] -ldl -lpthread
-//; eval_flags(c-sycl_cuda): [/usr/local/dpcpp-cuda/bin/clang++] -ldl -I/usr/local/dpcpp-cuda/include/sycl -L/usr/local/dpcpp-cuda/lib -lsycl -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice -fsycl-unnamed-lambda -lpthread
+//; eval_flags(c-sycl_cuda): [/usr/local/dpcpp-cuda/bin/clang++] -ldl -I/usr/local/dpcpp-cuda/include/sycl -L/usr/local/dpcpp-cuda/lib -lsycl -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice -fsycl-unnamed-lambda -lpthread -iquote/usr/local/cuda/include -L/usr/local/cuda/lib64 -lcuda -DSYCL_CUDA
 
 #include <CL/sycl.hpp>
 #include <dlfcn.h>
@@ -74,9 +74,17 @@ namespace ab {
 
     if (__BACKEND__ == "c-sycl_intel")
       ab_utils::Process({"dpcpp", path, "-std=c++17", "-lpthread", "-fPIC", "-shared", "-Wno-pass-failed", "-O3", "-ffast-math", "-march=skylake-avx512", "-o", path + ".out"}, 10);
-    else
-      ab_utils::Process({"/usr/local/dpcpp-cuda/bin/clang++", path, "-std=c++17", "-ldl", "-fPIC", "-shared", "-O2", "-I/usr/local/dpcpp-cuda/include/sycl", "-L/usr/local/dpcpp-cuda/lib", "-lsycl", "-fsycl", "-fsycl-targets=nvptx64-nvidia-cuda-sycldevice", "-fsycl-unnamed-lambda", "-Wno-unknown-cuda-version", "-Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75", "-o", path + ".out"}, 20);
-
+    else {
+    std::string gpu_arch = "50"; // Corresponds to the back-end default.
+#ifdef SYCL_CUDA
+#include "cuda.h"
+    int major, minor;
+    CHECK_OK(0 == cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, 0));
+    CHECK_OK(0 == cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, 0));
+    gpu_arch = std::to_string(major * 10 + minor);
+#endif
+      ab_utils::Process({"/usr/local/dpcpp-cuda/bin/clang++", path, "-std=c++17", "-ldl", "-fPIC", "-shared", "-O2", "-I/usr/local/dpcpp-cuda/include/sycl", "-L/usr/local/dpcpp-cuda/lib", "-lsycl", "-fsycl", "-fsycl-targets=nvptx64-nvidia-cuda-sycldevice", "-fsycl-unnamed-lambda", "-Wno-unknown-cuda-version", "-Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_" + gpu_arch, "-o", path + ".out"}, 20);  
+    }
     path = (path[0] == '/' ? path : "./" + path) + ".out";
     void* hmod = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     CHECK_OK(hmod != nullptr);

--- a/backends/c-sycl_intel/include/backend.hpp
+++ b/backends/c-sycl_intel/include/backend.hpp
@@ -8,6 +8,9 @@
 #include <dlfcn.h>
 #include <pthread.h>
 #include <malloc.h>
+#ifdef SYCL_CUDA
+#include "cuda.h"
+#endif
 
 namespace ab {
 
@@ -77,7 +80,6 @@ namespace ab {
     else {
     std::string gpu_arch = "50"; // Corresponds to the back-end default.
 #ifdef SYCL_CUDA
-#include "cuda.h"
     int major, minor;
     CHECK_OK(0 == cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, 0));
     CHECK_OK(0 == cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, 0));


### PR DESCRIPTION
This PR changes the GPU backend to use USM instead of `sycl::buffer`s that can lead to implicit data movements. 
This allows also to use the same interface for the `c-sycl_intel` target. It also addresses the `FIXME` comment given that we can allocate "void" memory. 

Signed-off-by: Michel Migdal michel.migdal@codeplay.com