### PR TITLE
append __habs for float16 abs in cuda backend

### DIFF
--- a/backends/c-hlsl_win64/config.py
+++ b/backends/c-hlsl_win64/config.py
@@ -154,6 +154,7 @@ float tanh_ex(float x) {
 #define hexp(x)     exp(x)
 #define hmax(x, y)  max(x, y)
 #define hmin(x, y)  min(x, y)
+#define __habs(x)     abs(x)
 
 {pre_defines}
 {lds}

--- a/lang/einstein_v2.py
+++ b/lang/einstein_v2.py
@@ -219,6 +219,8 @@ class OpTensor:
           return floor_op.when(self == floor_op, floor_op + const(1).cast(floor_op._dtype))
         if func_name in ('exp', 'sqrt', 'max', 'min') and self._dtype == 'float16':
           func_name = f'h{func_name}'
+        if func_name == 'abs' and self._dtype == 'float16':
+          func_name = f'__h{func_name}'
         if output_dtype is None:
           output_dtype = self._dtype
         return OpTensor('call', {"name": func_name, "inputs": [self] + others}, output_dtype)


### PR DESCRIPTION
reference to https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH____HALF__FUNCTIONS.html 

we should especially use __habs to do a half abs operation, and this pr had been tested pass under nnfusion codegen.

btw, why don't we select gen-code based on different backend instead of data type?